### PR TITLE
Reverted lifecycle and navigation3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,9 +17,11 @@ compose-accompanist = "0.37.3"
 hilt-navigation = "1.2.0"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.9.0"
-lifecycle = "2.10.0-alpha03"
+#noinspection GradleDependency See issue #15
+lifecycle = "2.10.0-alpha02"
 media3 = "1.8.0"
-navigation3 = "1.0.0-alpha08"
+#noinspection GradleDependency See issue #15
+navigation3 = "1.0.0-alpha07"
 test-junit = "1.3.0"
 test-espresso = "3.7.0"
 test-uiautomator = "2.3.0"


### PR DESCRIPTION
Seems that updating to lifecycle:2.10.0-alpha03 and navigation3:1.0.0-alpha08 breaks the viewmodel